### PR TITLE
Enables completion for zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's only prototype quality and I'm not a very good shell scripter nor a very go
 git clone https://github.com/minestarks/tsc-completion.git
 cd tsc-completion/
 npm install
-source ./register-tsc-completion.bash
+bash ./register-tsc-completion.bash
 ```
 
 Then start a new bash session.

--- a/register-tsc-completion.bash
+++ b/register-tsc-completion.bash
@@ -2,4 +2,4 @@
 
 echo complete -C `pwd`/tsc-completion.js tsc >> ~/.bashrc && echo completion spec added to ~/.bashrc || echo could not add completion to ~/.bashrc
 
-echo source `pwd`/zsh >> ~/.zshrc && echo completion spec added to ~/.zshrc || echo could not add completion to ~/.zshrc
+echo _tsc_completion_dir=`pwd` >> ~/.zshrc && echo source `pwd`/zsh >> ~/.zshrc && echo completion spec added to ~/.zshrc || echo could not add completion to ~/.zshrc

--- a/register-tsc-completion.bash
+++ b/register-tsc-completion.bash
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-echo complete -C `pwd`/tsc-completion.js tsc >> ~/.bashrc
+echo complete -C `pwd`/tsc-completion.js tsc >> ~/.bashrc && echo completion spec added to ~/.bashrc || echo could not add completion to ~/.bashrc
 
-echo completion spec added to ~/.bashrc
+echo source `pwd`/zsh >> ~/.zshrc && echo completion spec added to ~/.zshrc || echo could not add completion to ~/.zshrc

--- a/zsh
+++ b/zsh
@@ -1,10 +1,9 @@
-#!/usr/bin/env zsh
 _tsc_completions()
 {
   local reply
   local si=$IFS
   IFS=$'
-' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" "$(cd "$(dirname "$0")" && pwd)"/../tsc-completion.js tsc "${words[@]}"))
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" "$_tsc_completion_dir"/tsc-completion.js tsc "${words[@]}"))
   IFS=$si
   _describe 'values' reply
 }

--- a/zsh
+++ b/zsh
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+_tsc_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" "$(cd "$(dirname "$0")" && pwd)"/../tsc-completion.js tsc "${words[@]}"))
+  IFS=$si
+  _describe 'values' reply
+}
+compdef _tsc_completions tsc


### PR DESCRIPTION
Edited register-tsc-completion.bash to also register completion for zshrc. Added error messages for both register attempts.

New file, zsh, in root directory that is sourced by zshrc to avoid cluttering user's zshrc. 